### PR TITLE
Acking received messages

### DIFF
--- a/labview/labview_rabbitmq.c
+++ b/labview/labview_rabbitmq.c
@@ -172,7 +172,7 @@ int lv_amqp_basic_consume(int64_t conn_intptr, uint16_t channel, char *queuename
 	}
 
 	amqp_boolean_t NO_LOCAL = 0;
-	amqp_boolean_t NO_ACK = 1;
+	amqp_boolean_t NO_ACK = 0;
 	amqp_boolean_t EXCLUSIVE2 = 0;
 	amqp_basic_consume(conn, channel, amqp_cstring_bytes(queuename), amqp_empty_bytes, NO_LOCAL, NO_ACK, EXCLUSIVE2, amqp_empty_table);
 	/*amqp_basic_consume is used to register a consumer on the queue,
@@ -192,6 +192,7 @@ int lv_amqp_consume_message(int64_t conn_intptr, int timeout_sec, LStrHandle out
 	tval.tv_usec = 0;
 	amqp_rpc_reply_t res;
 	amqp_envelope_t envelope;
+	uint64_t delivery_tag;
 
 	amqp_maybe_release_buffers(conn);
 
@@ -212,6 +213,8 @@ int lv_amqp_consume_message(int64_t conn_intptr, int timeout_sec, LStrHandle out
 	{
 		headersToString(headers, concatenatedHeaders);
 	}
+	delivery_tag = envelope.delivery_tag;
+	amqp_basic_ack(conn, 1, delivery_tag, 0);
 
 	amqp_destroy_envelope(&envelope);
 	return status;

--- a/labview/labview_rabbitmq.c
+++ b/labview/labview_rabbitmq.c
@@ -15,7 +15,7 @@
 LABVIEW_PUBLIC_FUNCTION
 char *lv_rabbitmq_version(void)
 {
-	char *VERSION = "0.0.3";
+	char *VERSION = "0.0.4";
 	return VERSION;
 }
 


### PR DESCRIPTION
<!-- Thank you for submitting a pull request to our repository. -->

## Description

This PR changes how received messages are acked by library. No_ack settings is no longer uesd at setup and all messages are acked just after message data is copied into LabVIEW memory. 

## Changes Made

<!-- Please list the changes that you made in this pull request. -->

## Related Issues

<!-- Please list any related issues or pull requests.
Fixes #{bug number}  - use this specific format or issues won't be correctly linked to the PR
-->

## Checklist

<!-- Please check off the following items by putting an "x" in the box: -->

- [x] I have used a PR title that is descriptive enough for a release note.
- [x] I have tested these changes locally.
- [ ] I have added appropriate tests or updated existing tests.
- [ ] I have tested these changes on a cluster [name of the cluster] / customer [name of the customer]
- [ ] I have added appropriate documentation or updated existing documentation.
